### PR TITLE
github_prをactivitesのtypeへ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ type Response = {
     date: string;
     type:
       | "github"
+      | "github_pr"
       | "speaker_deck"
       | "qiita"
       | "zenn"


### PR DESCRIPTION
自分のjsonを確認したところ、activitesのtypeに`github_pr`が存在したため、`github_pr`を追加しました
```
{
"title": "yukyu30/era",
"url": "https://github.com/yukyu30/era/pulls?q=is:pr+author:yukyu30",
"date": "2023-04-29T00:00:00",
"type": "github_pr"
},
```