### PR TITLE
OpenAPI定義に「ユーザーのアイコン画像のURL」を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ GET https://lapras.com/public/<:share_id>.json
 | e_score | number | 技術力スコア | `3.4` ※ scoreが計算不可能な場合は0が返ります。 |
 | b_score | number  | ビジネス力スコア | `3.1` |
 | i_score | number | 影響力スコア | `2.2` |
+| iconimage_url | string | ユーザーのアイコン画像のURL | `"https://placehold.co/300x300.jpg"` |
 | qiita_articles | arrary | Qiita記事 | `[{"title": "hogehoge", "url": "https://qiita.com/hogehoge"}, "tags" ["foo"], "headlines": ["bar"], "stockers_count": 3, "updated_at": "020-07-26T08:10:11"]` |
 | zenn_articles | array  | Zenn記事 | `[{"title": "hoge", "url": "https://zenn.dev/hoge", "tags": ["foo"], "posted_at": "2022-10-03T08:36:43"}]`  |
 | blog_articles | array | ブログ記事 | `[{"title": "hoge", "url": "https://blog.com/hoge", "tags": ["foo"], "posted_at": "2022-10-03T08:36:43"}]` |
@@ -40,6 +41,7 @@ type Response = {
   e_score: number; // 技術力スコア,
   b_score: number; // ビジネス力スコア,
   i_score: number; // 影響力スコア,
+  iconimage_url: string; // ユーザーのアイコン画像のURL,
   qiita_articles: { // Qiita記事
     title: string;
     url: string;

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -53,6 +53,7 @@ components:
           e_score: 3
           b_score: 3
           i_score: 3
+          iconimage_url: https://placehold.co/300x300.jpg
           activities:
             - date: '2019-08-24T14:15:22Z'
               title: string
@@ -165,6 +166,10 @@ components:
           maximum: 5
           minimum: 0
           description: LAPRAS Influence score.
+        iconimage_url:
+          type: string
+          format: uri
+          description: User's icon image URL.
         activities:
           type: array
           items:


### PR DESCRIPTION
LAPRAS public API のレスポンスにユーザーのアイコン画像のURLを表す `iconimage_url` が含まれていますが、OpenAPI定義には含まれていなかったため追加しました